### PR TITLE
FIX billings when only 1 contract

### DIFF
--- a/api/api/__init__.py
+++ b/api/api/__init__.py
@@ -57,8 +57,8 @@ class CallEnqueue(Resource):
     def post(self):
         params = request.values.to_dict(flat=False)
         params = {k: params[k][0] if len(params[k]) <= 1 else params[k] for k in params}
-#        if not isinstance(params.get('contract'), list) and params in:
-#            params['contract'] = [params['contract']]
+        if params.get('contract') and not isinstance(params['contract'], list):
+            params['contract'] = [params['contract']]
         try:
             # IP or Telephone number must exist
             assert 'ipaddr' in params or 'phone' in params


### PR DESCRIPTION
When contract has only 1 item (i.e. [1]) it is not converted to list. 

fixes #45