### PR TITLE
IMP RQ use get_status() instead status

### DIFF
--- a/api/api/__init__.py
+++ b/api/api/__init__.py
@@ -133,7 +133,7 @@ class CallStatus(Resource):
                 "error": False,
                 "id": job.id,
                 "status": {
-                    "state": job.status,
+                    "state": job.get_status(),
                     "description": job.description,
                     "ttl": job.ttl,
                     "timeout": job.timeout,


### PR DESCRIPTION
Enables use of rq>1.0. It is necessary for python > 3.9