### PR TITLE
Added endpoints for testing and sending generic commands to modem

### DIFF
--- a/api/api/__init__.py
+++ b/api/api/__init__.py
@@ -237,16 +237,17 @@ class SendMoxa(Resource):
 
             split_write_sleep = commands.split(';')
             res = []
-            for write_sleep in split_write_sleep:
+            instruction_count = 0
+            for write_sleep, i in enumerate(split_write_sleep):
                 command, sleep = write_sleep.split(':')
                 sock.sendall(bytes(command + '\r\n', 'ascii'))
                 tmp_res = ''
                 while 'OK' not in tmp_res and 'ERR' not in tmp_res:
                     print('receiving')
                     data = sock.recv(16)
-                    tmp_res += data
+                    tmp_res += str(data)
                     print('received {}'.format(tmp_res))
-                res.append({'res': tmp_res})
+                res.append({'id': i+1, 'command': command, 'res': tmp_res})
                 time.sleep(int(sleep))
 
         except Exception as e:

--- a/api/api/__init__.py
+++ b/api/api/__init__.py
@@ -240,7 +240,7 @@ class SendMoxa(Resource):
 
             split_write_sleep = commands.split(';')
             res = []
-            instruction_count = 0
+            
             for i, write_sleep in enumerate(split_write_sleep):
                 command, sleep = write_sleep.split(':')
                 sock.sendall(bytes(command + '\r\n', 'ascii'))
@@ -267,7 +267,7 @@ resources = [
     (UserToken, '/get_token'),
     (UserTokenValid, '/is_token_valid'),
     (UserPassword, '/user/password'),
-    (ApiCatchall, '/<path:path>/'),
     (TestConnection, '/test'),
-    (SendMoxa, '/send')
+    (SendMoxa, '/send'),
+    (ApiCatchall, '/<path:path>/'),
 ]

--- a/api/api/__init__.py
+++ b/api/api/__init__.py
@@ -15,7 +15,10 @@ from jobs import call_using_custom_wrapper
 
 from redis import Redis
 import os
-from importlib.metadata import version
+try:
+    from importlib.metadata import version
+except:
+    from importlib_metadata import version
 import socket
 import time
 

--- a/api/api/__init__.py
+++ b/api/api/__init__.py
@@ -13,6 +13,12 @@ from pyreemote.telemeasure import ReemoteTCPIPWrapper, ReemoteModemWrapper, \
 from schemas import IPCallSchema, NumberCallSchema, MOXACallSchema
 from jobs import call_using_custom_wrapper
 
+from redis import Redis
+import os
+from importlib.metadata import version
+import socket
+import time
+
 # Python 2 and python3 compat for str type assertions
 try:
   basestring
@@ -195,11 +201,69 @@ class UserPassword(SecuredResource):
             })
 
 
+class TestConnection(Resource):
+    def get(self):
+        redis_name = os.environ.get('REDIS_NAME', "")
+        r = Redis(redis_name)
+        try:
+            r.ping()
+            is_alive = True
+        except Exception as e:
+            is_alive = False
+            print(repr(e))
+        finally:
+            r.close()
+
+        return jsonify({
+            'redis_ok': is_alive,
+            'iec870ree': version('iec870ree'),
+            'iec870ree_moxa': version('iec870ree_moxa')
+        })
+
+
+class SendMoxa(Resource):
+    def get(self):
+        address = request.args.get('address', False)
+        commands = request.args.get('commands', False)
+
+        if address:
+            ip, port = address.split(':')
+        else:
+            return 'Must define address parameter.'
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            sock.settimeout(5)
+            sock.connect((ip, int(port)))
+
+            split_write_sleep = commands.split(';')
+            res = []
+            for write_sleep in split_write_sleep:
+                command, sleep = write_sleep.split(':')
+                sock.sendall(bytes(command + '\r\n', 'ascii'))
+                tmp_res = ''
+                while 'OK' not in tmp_res and 'ERR' not in tmp_res:
+                    print('receiving')
+                    data = sock.recv(16)
+                    tmp_res += data
+                    print('received {}'.format(tmp_res))
+                res.append({'res': tmp_res})
+                time.sleep(int(sleep))
+
+        except Exception as e:
+            res = str(e)
+        finally:
+            sock.close()
+
+        return jsonify(res)
+
+
 resources = [
     (CallEnqueue, '/call/'),
     (CallStatus, '/call/<string:job_id>'),
     (UserToken, '/get_token'),
     (UserTokenValid, '/is_token_valid'),
     (UserPassword, '/user/password'),
-    (ApiCatchall, '/<path:path>/')
+    (ApiCatchall, '/<path:path>/'),
+    (TestConnection, '/test'),
+    (SendMoxa, '/send')
 ]

--- a/api/api/__init__.py
+++ b/api/api/__init__.py
@@ -248,7 +248,7 @@ class SendMoxa(Resource):
                 while 'OK' not in tmp_res and 'ERR' not in tmp_res:
                     print('receiving')
                     data = sock.recv(16)
-                    tmp_res += str(data)
+                    tmp_res += data.decode()
                     print('received {}'.format(tmp_res))
                 res.append({'id': i+1, 'command': command, 'res': tmp_res})
                 time.sleep(int(sleep))

--- a/api/api/__init__.py
+++ b/api/api/__init__.py
@@ -241,7 +241,7 @@ class SendMoxa(Resource):
             split_write_sleep = commands.split(';')
             res = []
             instruction_count = 0
-            for write_sleep, i in enumerate(split_write_sleep):
+            for i, write_sleep in enumerate(split_write_sleep):
                 command, sleep = write_sleep.split(':')
                 sock.sendall(bytes(command + '\r\n', 'ascii'))
                 tmp_res = ''

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -7,3 +7,4 @@ Redis
 RQ
 uwsgi
 iec870ree_moxa>=0.5.1
+importlib-metadata

--- a/pyreemote/pyreemote/telemeasure.py
+++ b/pyreemote/pyreemote/telemeasure.py
@@ -698,7 +698,10 @@ class ReemoteModemWrapper(object):
                 if os.environ['REEMOTE_PATH'] == 'local':
                     self.reemote = 'local'
                 else:
-                    self.reemote = urlparse(os.environ['REEMOTE_PATH'])
+                    reemote_url = os.environ['REEMOTE_PATH']
+                    if '/call' not in reemote_url:
+                        reemote_url = reemote_url + '/call'
+                    self.reemote = urlparse(reemote_url)
             else:
                 raise ValueError('Can\'t find the REEMOTE_PATH variable')
         else:


### PR DESCRIPTION
## Test endpoint
```
http://<reemote_ip>:5005/api/v1/test
```
Returns the following parameters:
- `redis_ok`: boolean indicating weather reemote can connect to the redis server.
- `iec870ree`: iec870ree module version
- `iec870ree_moxa`: iec870ree_moxa module version.

## Send commands endpoint
```
http://<reemote_ip>:5005/api/v1/send

http://<reemote_ip>:5005/api/v1/send?address=MOXA:950&commands=ATI:2;AT+CIND?:7
```
The following URL parameters are mandatory:
- `address`: takes the format `<ip>:<port>`
- `commands`: takes the format `<command>:<sleep>;<command>:<sleep>;...`.

**Warning:** Take into account some commands have special characters such as `+` or `?` and the url must be encoded.

Returns a list of objects of the following parameters:
- `id`: number of instruction sent to the modem.
- `command`: name of the instruction that was sent.
- `res`: response received from the modem.