### PR TITLE
IMP improve pyreemote requirements

### DIFF
--- a/pyreemote/setup.py
+++ b/pyreemote/setup.py
@@ -11,8 +11,8 @@ setup(
     author_email='devel@gisce.net',
     install_requires=[
         'requests',
-        'iec870ree>=0.11.3',
-        'iec870ree_moxa>=0.5.1',
+        'iec870ree>=0.12.1',
+        'iec870ree-moxa>=0.5.2',
     ],
     description='Python wrapper for iec870ree'
 )


### PR DESCRIPTION
Improve setup requirements:

* iec870ree >= 0.12.1
* iec870ree_moxa > iec870ree-moxa>=0.5.2